### PR TITLE
fix(deps): upgrade pyarrow to 24.0.0 for CVE-2023-47248

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -29,7 +29,7 @@ numexpr>=2.9.0
 cryptography>=48.0.0,<49.0.0
 # Security: Snyk - XSS vulnerability in Mako templates
 mako>=1.3.11,<2.0.0
-# Security: CVE-2024-52338 (CRITICAL) - Deserialization of untrusted data in IPC/Parquet readers
+# Security: CVE-2023-47248 (CRITICAL) - Deserialization of untrusted data in IPC/Parquet readers
 pyarrow>=24.0.0,<25.0.0
 # Security: CVE-2026-27459 - pyopenssl certificate validation
 pyopenssl>=26.0.0,<27.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -168,7 +168,6 @@ greenlet==3.5.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
-    #   sqlalchemy
 gunicorn==25.3.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0
@@ -294,7 +293,7 @@ prison==0.2.1
     # via flask-appbuilder
 prompt-toolkit==3.0.51
     # via click-repl
-pyarrow==12.0.0
+pyarrow==24.0.0
     # via
     #   -r requirements/base.in
     #   apache-superset (pyproject.toml)


### PR DESCRIPTION
### SUMMARY

Addresses **CVE-2023-47248**, a critical deserialization vulnerability in pyarrow IPC/Parquet/Feather readers (affected versions 0.14.0–14.0.0; fixed in 14.0.1).

`requirements/base.txt` was pinned to **pyarrow 12.0.0** (vulnerable) while `requirements/base.in` and `pyproject.toml` already constrained pyarrow to `>=24.0.0,<25`. This PR recompiles `base.txt` to sync the lockfile with the existing security constraint.

#### Vulnerability & patch summary

| Item | Before | After |
|------|--------|-------|
| **CVE** | CVE-2023-47248 (CRITICAL) | Patched |
| **pyarrow in `requirements/base.txt`** | 12.0.0 (vulnerable) | 24.0.0 |
| **pyarrow constraint in `base.in` / `pyproject.toml`** | `>=24.0.0,<25` | unchanged |
| **Minimum fixed version** | 14.0.1 | 24.0.0 (well above fix) |

#### pyarrow reader usage in codebase (no code changes required)

| Location | API | Data source | Risk |
|----------|-----|-------------|------|
| `superset/views/utils.py` | `pa.ipc.open_stream().read_all()` | SQL Lab results cache (msgpack payload) | Untrusted if cache compromised |
| `superset/commands/database/uploaders/columnar_reader.py` | `pd.read_parquet()`, `pq.ParquetFile()` | User-uploaded Parquet/ZIP files | Untrusted user input |
| `superset/examples/helpers.py` | `pd.read_parquet()` | Bundled example datasets | Trusted |
| `superset/sqllab/utils.py` | `pa.ipc.new_stream()` (writer) | Internal serialization | N/A (write-only) |
| `superset/db_engine_specs/hive.py` | `pq.write_table()` (writer) | Internal CSV→Hive upload | N/A (write-only) |

No Feather reader usage was found. Upgrading pyarrow is the correct mitigation; no application-code changes are needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — dependency-only change.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/commands/databases/columnar_reader_test.py tests/unit_tests/result_set_test.py -v
```

All 32 unit tests passed with pyarrow 24.0.0.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a security advisory reference related to IPC/Parquet reader handling.
  * Upgraded `pyarrow` to a newer version.
  * Cleaned up dependency metadata for `greenlet`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->