### PR TITLE
fix(deps): bump pyarrow to 24.0.0 to remediate CVE-2023-47248

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -294,7 +294,7 @@ prison==0.2.1
     # via flask-appbuilder
 prompt-toolkit==3.0.51
     # via click-repl
-pyarrow==12.0.0
+pyarrow==24.0.0
     # via
     #   -r requirements/base.in
     #   apache-superset (pyproject.toml)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### SUMMARY

Remediates **CVE-2023-47248**, a critical deserialization vulnerability in pyarrow IPC/Feather/Parquet readers affecting versions 0.14.0 through 14.0.0 (fixed in 14.0.1).

`requirements/base.txt` was temporarily pinned to the vulnerable `pyarrow==12.0.0` for a demo scenario. This PR restores the safe pinned version `pyarrow==24.0.0`, which is already declared in `pyproject.toml` and `requirements/base.in` (`>=24.0.0,<25.0.0`).

#### Remediation Summary

| Package | Old Version | New Version | CVE | Exposure Classification | Test Results |
|---------|-------------|-------------|-----|-------------------------|--------------|
| pyarrow | 12.0.0 (vulnerable) | 24.0.0 (fixed ≥14.0.1) | CVE-2023-47248 | **High** — production IPC and Parquet read paths are reachable | 389 passed |

#### Affected pyarrow Reader Usage (codebase audit)

| Location | API | Path | Exposure |
|----------|-----|------|----------|
| `superset/views/utils.py` | `pa.ipc.open_stream().read_all()` | SQL Lab results cache deserialization | **High** — deserializes cached query result payloads |
| `superset/commands/database/uploaders/columnar_reader.py` | `pd.read_parquet()`, `pq.ParquetFile()` | User-uploaded Parquet/ZIP files via database upload | **High** — user-supplied untrusted files |
| `superset/examples/helpers.py` | `pd.read_parquet()` | Local bundled example datasets | **Low** — trusted, read-only example files |
| *(none found)* | Feather readers | — | N/A |

Write-only pyarrow usage (not affected by this read-side CVE): `superset/sqllab/utils.py` (`pa.ipc.new_stream`), `superset/db_engine_specs/hive.py` (`pq.write_table`), dashboard/example export paths (`df.to_parquet`).

No application code changes were required — the existing constraint in `pyproject.toml` / `requirements/base.in` already targets a patched version; only the compiled lockfile pin needed restoration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — dependency-only change.

### TESTING INSTRUCTIONS

1. Verify the pinned version:
   ```bash
   grep pyarrow requirements/base.txt
   # Expected: pyarrow==24.0.0
   ```
2. Run pyarrow-related unit tests:
   ```bash
   pytest tests/unit_tests/commands/databases/columnar_reader_test.py \
          tests/unit_tests/result_set_test.py \
          tests/unit_tests/utils/csv_tests.py \
          tests/unit_tests/semantic_layers/ -q
   ```
3. Confirm installed version after `pip install -r requirements/base.txt`:
   ```bash
   python -c "import pyarrow; print(pyarrow.__version__)"
   # Expected: 24.0.0
   ```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb342ed1-bbde-419b-b5c9-392106b527d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb342ed1-bbde-419b-b5c9-392106b527d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

